### PR TITLE
Random Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ crate-type = ["static"]
 [dependencies]
 sdl2 = "*" # Surprise. It's actually an SDL2 wrapper.
 sdl2-sys = "*"
+rand = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "simple"
 description = "The simplest graphics library, inspired by LOVE2D"
-version = "0.0.4"
+version = "0.0.5"
 repository = "https://github.com/alexandercampbell/simple"
 keywords = ["simple","graphics","2D"]
 authors = ["Alexander Campbell <alexanderhcampbell@gmail.com>"]

--- a/examples/squares.rs
+++ b/examples/squares.rs
@@ -1,9 +1,10 @@
-#![feature(rand)]
 #![feature(core)]
 
 use std::num::Float;
-use std::rand::random;
 use std::num::SignedInt;
+
+extern crate rand;
+use rand::random;
 
 extern crate simple;
 use simple::{Window,Event,Rect};
@@ -13,7 +14,7 @@ static HEIGHT:i32 = 720;
 
 /// Return an f32 in the interval [0, upper_bound]
 /// Used to generate random positions for Square.
-fn rand_up_to(upper_bound: f32) -> f32 { random::<f32>().abs() * upper_bound }
+fn rand_up_to(upper_bound: f32) -> f32 {random::<f32>().abs() * upper_bound }
 
 /// Square is our game object. It has a position, movement vector, and color.
 #[derive(Debug,Copy,Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! The simplest graphics library, inspired by LOVE2D. See the README for more information.
 //!
 
+extern crate rand;
 extern crate sdl2;
 extern crate "sdl2-sys" as sdl2_sys;
 


### PR DESCRIPTION
Use rand crate instead of `feature(rand)`

Fixes compiler warnings showing up with latest nightly Rust.