### PR TITLE
Documentation

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -4,11 +4,27 @@ use sdl2::event::Event as SDL_Event;
 pub use sdl2::scancode::ScanCode as Key;
 pub use sdl2::mouse::Mouse as MouseButton;
 
-/// Event is an enumeration of the effects that a user can have on a running Window.
+/**
+ * Event is an enumeration of the effects that a user can have on a running Window.
+ *
+ * TODO: Add support for more events like touch events and window resizes.
+ */
 #[derive(Copy, Clone, PartialEq)]
 pub enum Event {
+    /// Keyboard is either a keypress or a keyrelease. The `is_down` bool tells you which :)
     Keyboard{is_down: bool, key: Key},
+
+    /// Mouse can be either a click or a click release. Refer to `is_down`. Note that the position
+    /// of the mouse at the time of the click is listed. The mouse may have moved in the meantime,
+    /// so for precision, you can use the position fields on this variant.
     Mouse{is_down: bool, button: MouseButton, mouse_x: i32, mouse_y: i32},
+
+    /// The user has signaled to the OS that the application should be killed. This could happen
+    /// through clicking the X in the corner of the window or using CMD-Q or Alt-F4 (depending on
+    /// the platform).
+    ///
+    /// You normally do not have to catch this event yourself. Window has built-in code to process
+    /// this case.
     Quit,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,17 @@ extern crate sdl2_image;
 extern crate sdl2_sys;
 
 // Re-export some of the symbols from the other modules.
-pub use event::{Key,MouseButton,Event};
-pub use shape::{Rect,Point,Polygon};
+pub use event::{Event};
+pub use shape::{Polygon,Rect,Point};
 pub use window::{Window,Image};
+
+// rustdoc has some bugs right now and the below code works around this. Rust issue link:
+// https://github.com/rust-lang/rust/issues/24305
+//
+// The specific issue is that renamed re-exports show up as their original names. This is a problem
+// because we re-export a couple SDL2 structs under slightly different names.
+pub use event::Key as Key;
+pub use event::MouseButton as MouseButton;
 
 mod event;
 mod shape;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,15 @@
 //!
 //! The simplest graphics library, inspired by LOVE2D. See the README for more information.
 //!
+//! Homepage: https://github.com/alexandercampbell/simple
+//!
 
 extern crate rand;
 extern crate sdl2;
 extern crate sdl2_image;
 extern crate sdl2_sys;
 
-// Re-export some of the symbols in event.rs
+// Re-export some of the symbols from the other modules.
 pub use event::{Key,MouseButton,Event};
 pub use shape::{Rect,Point,Polygon};
 pub use window::{Window,Image};

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -2,13 +2,12 @@
 extern crate sdl2;
 extern crate sdl2_sys;
 
-use std;
-
-// Might as well reuse the SDL2 structs wherever possible
+// Might as well reuse the SDL2 structs wherever possible. Less memory being copied around.
 pub use sdl2_sys::rect::Rect;
 pub use sdl2_sys::rect::Point;
 
+/// Polygon is a list of points with no special checking.
+///
 /// Polygon is mostly being set aside for now. May revisit in the future.
-pub struct Polygon {
-    pub points: std::vec::Vec<Point>,
-}
+pub type Polygon = Vec<Point>;
+

--- a/src/window.rs
+++ b/src/window.rs
@@ -197,7 +197,7 @@ impl<'a> Window<'a> {
     }
     pub fn draw_polygon(&mut self, polygon: shape::Polygon) {
         self.prepare_to_draw();
-        self.renderer.drawer().draw_points(&polygon.points[..])
+        self.renderer.drawer().draw_points(&polygon[..])
     }
 
     /// Display the image with its top-left corner at (x, y)

--- a/src/window.rs
+++ b/src/window.rs
@@ -115,7 +115,6 @@ impl<'a> Window<'a> {
                 None => break,
                 Some(sdl_event) => match Event::from_sdl2_event(sdl_event) {
                     Some(Event::Quit) => self.quit(),
-                    Some(Event::Keyboard{key: event::Key::Escape, ..})  => self.quit(),
 
                     // any other unrecognized event
                     Some(e) => (self.event_queue.push(e)),

--- a/src/window.rs
+++ b/src/window.rs
@@ -226,7 +226,11 @@ impl<'a> Window<'a> {
     }
 }
 
-/// Image represents a bitmap that can be drawn on the screen.
+/**
+ * Image represents a texture that can be drawn on the screen.
+ *
+ * Images are immutable, in the sense that they have no methods to modify their contents.
+ */
 pub struct Image {
     texture:    render::Texture,
     width:      i32,

--- a/src/window.rs
+++ b/src/window.rs
@@ -13,11 +13,15 @@ use std::path::Path;
 use event::{self,Event};
 use shape;
 
-///
-/// A Window can display graphics, play sounds, and handle events.
-///
-/// Creating multiple Windows is untested!
-///
+/**
+ * A Window can display graphics and handle events.
+ *
+ * A Window has a draw color at all times, and that color is applied to every operation. If you set
+ * the color to `(255, 0, 0)`, all drawn graphics and images will have a red tint.
+ *
+ * Creating multiple Windows is untested and will probably crash!
+ *
+ */
 pub struct Window<'a> {
     // sdl graphics
     context:                    sdl2::sdl::Sdl,
@@ -34,7 +38,7 @@ pub struct Window<'a> {
 }
 
 /// Top-level Running / Creation Methods
-/// ------------------------------------
+/// ====================================
 impl<'a> Window<'a> {
     /// Intialize a new running window. `name` is used as a caption.
     pub fn new(name: &str, width: u16, height: u16) -> Self {
@@ -86,8 +90,10 @@ impl<'a> Window<'a> {
     }
 
     /// Redrawing and update the display, while maintaining a consistent framerate and updating the
-    /// event queue. You should draw your objects immediately before you call this function. NOTE:
-    /// This function returns false if the program should terminate.
+    /// event queue. You should draw your objects immediately before you call this function.
+    ///
+    /// NOTE: This function returns false if the program should terminate. This allows for nice
+    /// constructs like `while app.next_frame() { ... }`
     pub fn next_frame(&mut self) -> bool {
         if !self.running {
             return false;
@@ -163,7 +169,7 @@ impl<'a> Window<'a> {
 }
 
 /// Drawing Methods
-/// ---------------
+/// ===============
 impl<'a> Window<'a> {
     /// Windows have a color set on them at all times. This color is applied to every draw
     /// operation. To "unset" the color, call set_color with (255,255,255,255)
@@ -233,8 +239,8 @@ impl Image {
     pub fn get_height(&self) -> i32 { self.height }
 }
 
-/// Creation Methods
-/// ----------------
+/// Resource Loading Methods
+/// ========================
 impl<'a> Window<'a> {
     /// Load the image at the path you specify.
     pub fn load_image(&self, filename: &Path) -> Result<Image,String> {
@@ -246,6 +252,10 @@ impl<'a> Window<'a> {
             texture:    texture,
         })
     }
+
+    // TODO: font loading support
+    //
+    // https://github.com/alexandercampbell/simple/issues/10
 }
 
 // Dtor for Window.


### PR DESCRIPTION
Improve the documentation strings wherever possible.

There are some annoying reexport bugs in `rustdoc` that I'm [working around](https://github.com/alexandercampbell/simple/commit/09d8e7fa4e87e20951feca1ddedaa2e44b7ad76b) for now.